### PR TITLE
Fixes #15 vertx-hawkular-metrics should work with a Metrics server protected by Accounts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
   <properties>
     <!-- Versioning properties -->
     <stack.version>3.3.0-SNAPSHOT</stack.version>
-    <version.org.wildfly>9.0.1.Final</version.org.wildfly>
+    <version.org.wildfly>10.0.0.Final</version.org.wildfly>
     <version.org.hawkular.metrics>0.12.1.Final</version.org.hawkular.metrics>
     <version.org.hawkular.embedded-cassandra>0.3.5.Final</version.org.hawkular.embedded-cassandra>
     <!-- Test setup properties -->

--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -28,6 +28,10 @@ Set the maximum number of metrics in a batch. To reduce the number of HTTP excha
 +++
 Set whether metrics will be enabled on the Vert.x instance. Metrics are not enabled by default.
 +++
+|[[hawkularServerOptions]]`hawkularServerOptions`|`link:dataobjects.html#HawkularServerOptions[HawkularServerOptions]`|
++++
+Set the options specific to a Hawkular server.
++++
 |[[host]]`host`|`String`|
 +++
 Set the Hawkular Metrics service host. Defaults to <code>localhost</code>.
@@ -66,6 +70,54 @@ Set the metric name prefix. Metric names are not prefixed by default. Prefixing 
 +++
 Set the metric collection interval (in seconds). Defaults to <code>1</code>.
 +++
+|[[serverType]]`serverType`|`link:enums.html#ServerType[ServerType]`|
++++
+Set the Hawkular server type (standalone Metrics, Hawkular, ... etc). Defaults to <code>METRICS</code>.
++++
+|[[standaloneMetricsOptions]]`standaloneMetricsOptions`|`link:dataobjects.html#StandaloneMetricsOptions[StandaloneMetricsOptions]`|
++++
+Set the options specific to a standalone Metrics server.
++++
+|===
+
+[[HawkularServerOptions]]
+== HawkularServerOptions
+
+++++
+ Options specific to a Hawkular server.
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[id]]`id`|`String`|
++++
+Set the identifier used for authentication.
++++
+|[[persona]]`persona`|`String`|
++++
+Set the Hawkular Persona identifier. This is used to impersonate an organization with user credentials.
++++
+|[[secret]]`secret`|`String`|
++++
+Set the secret used for authentication.
++++
+|===
+
+[[StandaloneMetricsOptions]]
+== StandaloneMetricsOptions
+
+++++
+ Options specific to a standalone Metrics server.
+++++
+'''
+
+[cols=">25%,^25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
 |[[tenant]]`tenant`|`String`|
 +++
 Set the Hawkular tenant. Defaults to <code>default</code>.

--- a/src/main/asciidoc/enums.adoc
+++ b/src/main/asciidoc/enums.adoc
@@ -1,0 +1,24 @@
+= Enums
+
+[[ServerType]]
+== ServerType
+
+++++
+ Remote server flavor (standalone Metrics server, Hawkular server, ... etc).
+++++
+'''
+
+[cols=">25%,75%"]
+[frame="topbot"]
+|===
+^|Name | Description
+|[[METRICS]]`METRICS`|
++++
+Standalone Metrics server.
++++
+|[[HAWKULAR]]`HAWKULAR`|
++++
+Hawkular server.
++++
+|===
+

--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -64,9 +64,29 @@ def vertx = Vertx.vertx([
 
 ----
 
-=== Hawkular tenant selection
+=== Server type
 
-Hawkular is a multi-tenant solution, and _vertx-hawkular-metrics_ can send metrics for a tenant other than `default`:
+_vertx-hawkular-metrics_ is able to communicate with a standalone Hawkular Metrics server as well as a full-fledged Hawkular server.
+Set the server type option to select your server flavor:
+
+[source,groovy]
+----
+import io.vertx.ext.hawkular.ServerType
+import io.vertx.groovy.core.Vertx
+def vertx = Vertx.vertx([
+  metricsOptions:[
+    enabled:true,
+    serverType:ServerType.HAWKULAR
+  ]
+])
+
+----
+
+Standalone Metrics server is the default.
+
+==== Tenant selection with a standalone Metrics server
+
+Hawkular Metrics is a multi-tenant solution, and _vertx-hawkular-metrics_ can send metrics for a tenant other than `default`:
 
 [source,groovy]
 ----
@@ -74,7 +94,30 @@ import io.vertx.groovy.core.Vertx
 def vertx = Vertx.vertx([
   metricsOptions:[
     enabled:true,
-    tenant:"sales-department"
+    standaloneMetricsOptions:[
+      tenant:"sales-department"
+    ]
+  ]
+])
+
+----
+
+==== Authentication with a Hawkular server
+
+Requests sent to an Hawkular server must be authenticated:
+
+[source,groovy]
+----
+import io.vertx.ext.hawkular.ServerType
+import io.vertx.groovy.core.Vertx
+def vertx = Vertx.vertx([
+  metricsOptions:[
+    enabled:true,
+    serverType:ServerType.HAWKULAR,
+    hawkularServerOptions:[
+      id:"username",
+      secret:"password"
+    ]
   ]
 ])
 

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -57,16 +57,50 @@ Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(
 ));
 ----
 
-=== Hawkular tenant selection
+=== Server type
 
-Hawkular is a multi-tenant solution, and _vertx-hawkular-metrics_ can send metrics for a tenant other than `default`:
+_vertx-hawkular-metrics_ is able to communicate with a standalone Hawkular Metrics server as well as a full-fledged Hawkular server.
+Set the server type option to select your server flavor:
 
 [source,java]
 ----
 Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(
   new VertxHawkularOptions()
     .setEnabled(true)
-    .setTenant("sales-department")
+    .setServerType(ServerType.HAWKULAR)
+));
+----
+
+Standalone Metrics server is the default.
+
+==== Tenant selection with a standalone Metrics server
+
+Hawkular Metrics is a multi-tenant solution, and _vertx-hawkular-metrics_ can send metrics for a tenant other than `default`:
+
+[source,java]
+----
+Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(
+  new VertxHawkularOptions()
+    .setEnabled(true)
+    .setStandaloneMetricsOptions(new StandaloneMetricsOptions().setTenant("sales-department"))
+));
+----
+
+==== Authentication with a Hawkular server
+
+Requests sent to an Hawkular server must be authenticated:
+
+[source,java]
+----
+Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(
+  new VertxHawkularOptions()
+    .setEnabled(true)
+    .setServerType(ServerType.HAWKULAR)
+    .setHawkularServerOptions(
+      new HawkularServerOptions()
+        .setId("username")
+        .setSecret("password")
+    )
 ));
 ----
 

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -64,9 +64,10 @@ var vertx = Vertx.vertx({
 
 ----
 
-=== Hawkular tenant selection
+=== Server type
 
-Hawkular is a multi-tenant solution, and _vertx-hawkular-metrics_ can send metrics for a tenant other than `default`:
+_vertx-hawkular-metrics_ is able to communicate with a standalone Hawkular Metrics server as well as a full-fledged Hawkular server.
+Set the server type option to select your server flavor:
 
 [source,js]
 ----
@@ -74,7 +75,47 @@ var Vertx = require("vertx-js/vertx");
 var vertx = Vertx.vertx({
   "metricsOptions" : {
     "enabled" : true,
-    "tenant" : "sales-department"
+    "serverType" : 'HAWKULAR'
+  }
+});
+
+----
+
+Standalone Metrics server is the default.
+
+==== Tenant selection with a standalone Metrics server
+
+Hawkular Metrics is a multi-tenant solution, and _vertx-hawkular-metrics_ can send metrics for a tenant other than `default`:
+
+[source,js]
+----
+var Vertx = require("vertx-js/vertx");
+var vertx = Vertx.vertx({
+  "metricsOptions" : {
+    "enabled" : true,
+    "standaloneMetricsOptions" : {
+      "tenant" : "sales-department"
+    }
+  }
+});
+
+----
+
+==== Authentication with a Hawkular server
+
+Requests sent to an Hawkular server must be authenticated:
+
+[source,js]
+----
+var Vertx = require("vertx-js/vertx");
+var vertx = Vertx.vertx({
+  "metricsOptions" : {
+    "enabled" : true,
+    "serverType" : 'HAWKULAR',
+    "hawkularServerOptions" : {
+      "id" : "username",
+      "secret" : "password"
+    }
   }
 });
 

--- a/src/main/asciidoc/ruby/index.adoc
+++ b/src/main/asciidoc/ruby/index.adoc
@@ -64,9 +64,10 @@ vertx = Vertx::Vertx.vertx({
 
 ----
 
-=== Hawkular tenant selection
+=== Server type
 
-Hawkular is a multi-tenant solution, and _vertx-hawkular-metrics_ can send metrics for a tenant other than `default`:
+_vertx-hawkular-metrics_ is able to communicate with a standalone Hawkular Metrics server as well as a full-fledged Hawkular server.
+Set the server type option to select your server flavor:
 
 [source,ruby]
 ----
@@ -74,7 +75,47 @@ require 'vertx/vertx'
 vertx = Vertx::Vertx.vertx({
   'metricsOptions' => {
     'enabled' => true,
-    'tenant' => "sales-department"
+    'serverType' => :HAWKULAR
+  }
+})
+
+----
+
+Standalone Metrics server is the default.
+
+==== Tenant selection with a standalone Metrics server
+
+Hawkular Metrics is a multi-tenant solution, and _vertx-hawkular-metrics_ can send metrics for a tenant other than `default`:
+
+[source,ruby]
+----
+require 'vertx/vertx'
+vertx = Vertx::Vertx.vertx({
+  'metricsOptions' => {
+    'enabled' => true,
+    'standaloneMetricsOptions' => {
+      'tenant' => "sales-department"
+    }
+  }
+})
+
+----
+
+==== Authentication with a Hawkular server
+
+Requests sent to an Hawkular server must be authenticated:
+
+[source,ruby]
+----
+require 'vertx/vertx'
+vertx = Vertx::Vertx.vertx({
+  'metricsOptions' => {
+    'enabled' => true,
+    'serverType' => :HAWKULAR,
+    'hawkularServerOptions' => {
+      'id' => "username",
+      'secret' => "password"
+    }
   }
 })
 

--- a/src/main/generated/io/vertx/ext/hawkular/HawkularServerOptionsConverter.java
+++ b/src/main/generated/io/vertx/ext/hawkular/HawkularServerOptionsConverter.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.ext.hawkular;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+
+/**
+ * Converter for {@link io.vertx.ext.hawkular.HawkularServerOptions}.
+ *
+ * NOTE: This class has been automatically generated from the {@link io.vertx.ext.hawkular.HawkularServerOptions} original class using Vert.x codegen.
+ */
+public class HawkularServerOptionsConverter {
+
+  public static void fromJson(JsonObject json, HawkularServerOptions obj) {
+    if (json.getValue("id") instanceof String) {
+      obj.setId((String)json.getValue("id"));
+    }
+    if (json.getValue("persona") instanceof String) {
+      obj.setPersona((String)json.getValue("persona"));
+    }
+    if (json.getValue("secret") instanceof String) {
+      obj.setSecret((String)json.getValue("secret"));
+    }
+  }
+
+  public static void toJson(HawkularServerOptions obj, JsonObject json) {
+    if (obj.getId() != null) {
+      json.put("id", obj.getId());
+    }
+    if (obj.getPersona() != null) {
+      json.put("persona", obj.getPersona());
+    }
+    if (obj.getSecret() != null) {
+      json.put("secret", obj.getSecret());
+    }
+  }
+}

--- a/src/main/generated/io/vertx/ext/hawkular/StandaloneMetricsOptionsConverter.java
+++ b/src/main/generated/io/vertx/ext/hawkular/StandaloneMetricsOptionsConverter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.vertx.ext.hawkular;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+
+/**
+ * Converter for {@link io.vertx.ext.hawkular.StandaloneMetricsOptions}.
+ *
+ * NOTE: This class has been automatically generated from the {@link io.vertx.ext.hawkular.StandaloneMetricsOptions} original class using Vert.x codegen.
+ */
+public class StandaloneMetricsOptionsConverter {
+
+  public static void fromJson(JsonObject json, StandaloneMetricsOptions obj) {
+    if (json.getValue("tenant") instanceof String) {
+      obj.setTenant((String)json.getValue("tenant"));
+    }
+  }
+
+  public static void toJson(StandaloneMetricsOptions obj, JsonObject json) {
+    if (obj.getTenant() != null) {
+      json.put("tenant", obj.getTenant());
+    }
+  }
+}

--- a/src/main/generated/io/vertx/ext/hawkular/VertxHawkularOptionsConverter.java
+++ b/src/main/generated/io/vertx/ext/hawkular/VertxHawkularOptionsConverter.java
@@ -36,6 +36,9 @@ public class VertxHawkularOptionsConverter {
     if (json.getValue("enabled") instanceof Boolean) {
       obj.setEnabled((Boolean)json.getValue("enabled"));
     }
+    if (json.getValue("hawkularServerOptions") instanceof JsonObject) {
+      obj.setHawkularServerOptions(new io.vertx.ext.hawkular.HawkularServerOptions((JsonObject)json.getValue("hawkularServerOptions")));
+    }
     if (json.getValue("host") instanceof String) {
       obj.setHost((String)json.getValue("host"));
     }
@@ -60,8 +63,11 @@ public class VertxHawkularOptionsConverter {
     if (json.getValue("schedule") instanceof Number) {
       obj.setSchedule(((Number)json.getValue("schedule")).intValue());
     }
-    if (json.getValue("tenant") instanceof String) {
-      obj.setTenant((String)json.getValue("tenant"));
+    if (json.getValue("serverType") instanceof String) {
+      obj.setServerType(io.vertx.ext.hawkular.ServerType.valueOf((String)json.getValue("serverType")));
+    }
+    if (json.getValue("standaloneMetricsOptions") instanceof JsonObject) {
+      obj.setStandaloneMetricsOptions(new io.vertx.ext.hawkular.StandaloneMetricsOptions((JsonObject)json.getValue("standaloneMetricsOptions")));
     }
   }
 
@@ -84,8 +90,8 @@ public class VertxHawkularOptionsConverter {
       json.put("prefix", obj.getPrefix());
     }
     json.put("schedule", obj.getSchedule());
-    if (obj.getTenant() != null) {
-      json.put("tenant", obj.getTenant());
+    if (obj.getServerType() != null) {
+      json.put("serverType", obj.getServerType().name());
     }
   }
 }

--- a/src/main/java/examples/MetricsExamples.java
+++ b/src/main/java/examples/MetricsExamples.java
@@ -20,6 +20,9 @@ import io.vertx.core.VertxOptions;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.json.JsonObject;
 import io.vertx.docgen.Source;
+import io.vertx.ext.hawkular.HawkularServerOptions;
+import io.vertx.ext.hawkular.ServerType;
+import io.vertx.ext.hawkular.StandaloneMetricsOptions;
 import io.vertx.ext.hawkular.VertxHawkularOptions;
 
 /**
@@ -46,11 +49,32 @@ public class MetricsExamples {
     ));
   }
 
+  public void setupServerType() {
+    Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(
+      new VertxHawkularOptions()
+        .setEnabled(true)
+        .setServerType(ServerType.HAWKULAR)
+    ));
+  }
+
   public void setupTenant() {
     Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(
       new VertxHawkularOptions()
         .setEnabled(true)
-        .setTenant("sales-department")
+        .setStandaloneMetricsOptions(new StandaloneMetricsOptions().setTenant("sales-department"))
+    ));
+  }
+
+  public void setupHawkularAuth() {
+    Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(
+      new VertxHawkularOptions()
+        .setEnabled(true)
+        .setServerType(ServerType.HAWKULAR)
+        .setHawkularServerOptions(
+          new HawkularServerOptions()
+            .setId("username")
+            .setSecret("password")
+        )
     ));
   }
 

--- a/src/main/java/io/vertx/ext/hawkular/HawkularServerOptions.java
+++ b/src/main/java/io/vertx/ext/hawkular/HawkularServerOptions.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.hawkular;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Options specific to a Hawkular server.
+ *
+ * @author Thomas Segismont
+ */
+@DataObject(generateConverter = true)
+public class HawkularServerOptions {
+
+  private String id;
+  private String secret;
+  private String persona;
+
+  public HawkularServerOptions() {
+  }
+
+  public HawkularServerOptions(HawkularServerOptions other) {
+    id = other.id;
+    secret = other.secret;
+    persona = other.persona;
+  }
+
+  public HawkularServerOptions(JsonObject json) {
+    HawkularServerOptionsConverter.fromJson(json, this);
+  }
+
+  /**
+   * @return the identifier used for authentication
+   */
+  public String getId() {
+    return id;
+  }
+
+  /**
+   * Set the identifier used for authentication.
+   */
+  public HawkularServerOptions setId(String id) {
+    this.id = id;
+    return this;
+  }
+
+  /**
+   * @return the secret used for authentication
+   */
+  public String getSecret() {
+    return secret;
+  }
+
+  /**
+   * Set the secret used for authentication.
+   */
+  public HawkularServerOptions setSecret(String secret) {
+    this.secret = secret;
+    return this;
+  }
+
+  /**
+   * @return the Hawkular Persona identifier
+   */
+  public String getPersona() {
+    return persona;
+  }
+
+  /**
+   * Set the Hawkular Persona identifier. This is used to impersonate an organization with user credentials.
+   */
+  public HawkularServerOptions setPersona(String persona) {
+    this.persona = persona;
+    return this;
+  }
+}

--- a/src/main/java/io/vertx/ext/hawkular/ServerType.java
+++ b/src/main/java/io/vertx/ext/hawkular/ServerType.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.hawkular;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+/**
+ * Remote server flavor (standalone Metrics server, Hawkular server, ... etc).
+ *
+ * @author Thomas Segismont
+ */
+@VertxGen
+public enum ServerType {
+  /**
+   * Standalone Metrics server.
+   */
+  METRICS,
+  /**
+   * Hawkular server.
+   */
+  HAWKULAR;
+}

--- a/src/main/java/io/vertx/ext/hawkular/StandaloneMetricsOptions.java
+++ b/src/main/java/io/vertx/ext/hawkular/StandaloneMetricsOptions.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.hawkular;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Options specific to a standalone Metrics server.
+ *
+ * @author Thomas Segismont
+ */
+@DataObject(generateConverter = true)
+public class StandaloneMetricsOptions {
+  /**
+   * The default Hawkular tenant = default.
+   */
+  public static final String DEFAULT_TENANT = "default";
+
+  private String tenant;
+
+  public StandaloneMetricsOptions() {
+    tenant = DEFAULT_TENANT;
+  }
+
+  public StandaloneMetricsOptions(StandaloneMetricsOptions other) {
+    tenant = other.tenant;
+  }
+
+  public StandaloneMetricsOptions(JsonObject json) {
+    StandaloneMetricsOptionsConverter.fromJson(json, this);
+  }
+
+  /**
+   * @return the Hawkular tenant
+   */
+  public String getTenant() {
+    return tenant;
+  }
+
+  /**
+   * Set the Hawkular tenant. Defaults to {@code default}.
+   */
+  public StandaloneMetricsOptions setTenant(String tenant) {
+    this.tenant = tenant;
+    return this;
+  }
+}

--- a/src/main/java/io/vertx/ext/hawkular/VertxHawkularOptions.java
+++ b/src/main/java/io/vertx/ext/hawkular/VertxHawkularOptions.java
@@ -20,6 +20,8 @@ import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.metrics.MetricsOptions;
 
+import static io.vertx.ext.hawkular.ServerType.*;
+
 /**
  * Vert.x Hawkular monitoring configuration.
  *
@@ -43,9 +45,9 @@ public class VertxHawkularOptions extends MetricsOptions {
   public static final String DEFAULT_METRICS_URI = "/hawkular/metrics";
 
   /**
-   * The default Hawkular tenant = default.
+   * The default server type = METRICS.
    */
-  public static final String DEFAULT_TENANT = "default";
+  public static final ServerType DEFAULT_SERVER_TYPE = METRICS;
 
   /**
    * Default value for metric collection interval (in seconds) = 1.
@@ -82,7 +84,9 @@ public class VertxHawkularOptions extends MetricsOptions {
   private int port;
   private HttpClientOptions httpOptions;
   private String metricsServiceUri;
-  private String tenant;
+  private ServerType serverType;
+  private StandaloneMetricsOptions standaloneMetricsOptions;
+  private HawkularServerOptions hawkularServerOptions;
   private int schedule;
   private String prefix;
   private int batchSize;
@@ -95,7 +99,9 @@ public class VertxHawkularOptions extends MetricsOptions {
     port = DEFAULT_PORT;
     httpOptions = new HttpClientOptions();
     metricsServiceUri = DEFAULT_METRICS_URI;
-    tenant = DEFAULT_TENANT;
+    serverType = DEFAULT_SERVER_TYPE;
+    standaloneMetricsOptions = new StandaloneMetricsOptions();
+    hawkularServerOptions = new HawkularServerOptions();
     schedule = DEFAULT_SCHEDULE;
     prefix = DEFAULT_PREFIX;
     batchSize = DEFAULT_BATCH_SIZE;
@@ -110,7 +116,9 @@ public class VertxHawkularOptions extends MetricsOptions {
     port = other.port;
     httpOptions = other.httpOptions != null ? new HttpClientOptions(other.httpOptions) : new HttpClientOptions();
     metricsServiceUri = other.metricsServiceUri;
-    tenant = other.tenant;
+    serverType = other.serverType;
+    standaloneMetricsOptions = other.standaloneMetricsOptions;
+    hawkularServerOptions = other.hawkularServerOptions;
     schedule = other.schedule;
     prefix = other.prefix;
     batchSize = other.batchSize;
@@ -186,17 +194,48 @@ public class VertxHawkularOptions extends MetricsOptions {
   }
 
   /**
-   * @return the Hawkular tenant
+   * @return the server type
    */
-  public String getTenant() {
-    return tenant;
+  public ServerType getServerType() {
+    return serverType;
   }
 
   /**
-   * Set the Hawkular tenant. Defaults to {@code default}.
+   * Set the Hawkular server type (standalone Metrics, Hawkular, ... etc). Defaults to {@code METRICS}.
    */
-  public VertxHawkularOptions setTenant(String tenant) {
-    this.tenant = tenant;
+  public VertxHawkularOptions setServerType(ServerType serverType) {
+    this.serverType = serverType;
+    return this;
+  }
+
+  /**
+   * @return the options specific to a standalone Metrics server
+   */
+  public StandaloneMetricsOptions getStandaloneMetricsOptions() {
+    return standaloneMetricsOptions;
+  }
+
+  /**
+   * Set the options specific to a standalone Metrics server.
+   */
+  public VertxHawkularOptions setStandaloneMetricsOptions(StandaloneMetricsOptions standaloneMetricsOptions) {
+    this.standaloneMetricsOptions = standaloneMetricsOptions;
+    return this;
+  }
+
+  /**
+   * @return the options specific to a Hawkular server
+   */
+  public HawkularServerOptions getHawkularServerOptions() {
+    return hawkularServerOptions;
+  }
+
+
+  /**
+   * Set the options specific to a Hawkular server.
+   */
+  public VertxHawkularOptions setHawkularServerOptions(HawkularServerOptions hawkularServerOptions) {
+    this.hawkularServerOptions = hawkularServerOptions;
     return this;
   }
 

--- a/src/main/java/io/vertx/ext/hawkular/impl/UnsupportedServerTypeException.java
+++ b/src/main/java/io/vertx/ext/hawkular/impl/UnsupportedServerTypeException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.hawkular.impl;
+
+import io.vertx.ext.hawkular.ServerType;
+
+/**
+ * @author Thomas Segismont
+ */
+public class UnsupportedServerTypeException extends RuntimeException {
+
+  public UnsupportedServerTypeException(ServerType serverType) {
+    super(serverType.name());
+  }
+}

--- a/src/main/java/io/vertx/ext/hawkular/package-info.java
+++ b/src/main/java/io/vertx/ext/hawkular/package-info.java
@@ -67,13 +67,34 @@
  * {@link examples.MetricsExamples#setupRemote()}
  * ----
  *
- * === Hawkular tenant selection
+ * === Server type
  *
- * Hawkular is a multi-tenant solution, and _${maven.artifactId}_ can send metrics for a tenant other than `default`:
+ * _${maven.artifactId}_ is able to communicate with a standalone Hawkular Metrics server as well as a full-fledged Hawkular server.
+ * Set the server type option to select your server flavor:
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.MetricsExamples#setupServerType()}
+ * ----
+ *
+ * Standalone Metrics server is the default.
+ *
+ * ==== Tenant selection with a standalone Metrics server
+ *
+ * Hawkular Metrics is a multi-tenant solution, and _${maven.artifactId}_ can send metrics for a tenant other than `default`:
  *
  * [source,$lang]
  * ----
  * {@link examples.MetricsExamples#setupTenant()}
+ * ----
+ *
+ * ==== Authentication with a Hawkular server
+ *
+ * Requests sent to an Hawkular server must be authenticated:
+ *
+ * [source,$lang]
+ * ----
+ * {@link examples.MetricsExamples#setupHawkularAuth()}
  * ----
  *
  * === HTTPS and other HTTP related options

--- a/src/test/groovy/io/vertx/ext/hawkular/impl/BaseITest.groovy
+++ b/src/test/groovy/io/vertx/ext/hawkular/impl/BaseITest.groovy
@@ -90,15 +90,17 @@ abstract class BaseITest {
   static def Map createMetricsOptions(String tenantId) {
     def vertxOptions = [
       metricsOptions: [
-        enabled : true,
-        host    : SERVER_URL_PROPS.host,
-        port    : SERVER_URL_PROPS.port,
-        tenant  : tenantId,
-        prefix  : METRIC_PREFIX,
-        schedule: SECONDS.convert(SCHEDULE, MILLISECONDS),
+        enabled                 : true,
+        host                    : SERVER_URL_PROPS.host,
+        port                    : SERVER_URL_PROPS.port,
+        standaloneMetricsOptions: [
+          tenant: tenantId
+        ],
+        prefix                  : METRIC_PREFIX,
+        schedule                : SECONDS.convert(SCHEDULE, MILLISECONDS),
         // Event bus bridge configuration
-        metricsBridgeEnabled : true,
-        metricsBridgeAddress: "hawkular.metrics"
+        metricsBridgeEnabled    : true,
+        metricsBridgeAddress    : "hawkular.metrics"
       ]
     ]
     vertxOptions


### PR DESCRIPTION
Since v0.12, the Metrics service inside Hawkular is protected by Hawkular accounts. So the SPI impl must be able to connect to a standalone Metrics server or a full Hawkular server.
