### PR TITLE
Enable sending designed kinds of mertics

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -65,10 +65,12 @@ VertxHawkularOptions vertxHawkularOptions = new VertxHawkularOptions() // <1>
         .setSchedule(3); // <6>
 vertxHawkularOptions.setEnabled(true); // <7>
 
-VertxOptions vertxOptions = new VertxOptions()
-        .setMetricsOptions(vertxHawkularOptions); // <8>
+vertxHawkularOptions.addDisabledMetricsType(MetricsType.NET_SERVER); // <8>
 
-Vertx vertx = Vertx.vertx(vertxOptions); // <9>
+VertxOptions vertxOptions = new VertxOptions()
+        .setMetricsOptions(vertxHawkularOptions); // <9>
+
+Vertx vertx = Vertx.vertx(vertxOptions); // <10>
 ----
 <1> `VertxHawkularOptions` extends `io.vertx.core.metrics.MetricsOptions`
 <2> Host of the Hawkular Metrics server, defaults to `localhost`
@@ -78,8 +80,10 @@ Vertx vertx = Vertx.vertx(vertxOptions); // <9>
 by default
 <6> How often (in seconds) metrics will be collected and sent to the Hawkular server, defaults to `1` second
 <7> The *Vert.x Metrics SPI is disabled by default*, so make sure to enable it
-<8> Add your `VertxHawkularOptions` to the `io.vertx.core.VertxOptions`
-<9> Create the Vert.x instance
+<8> Disable unwanted metrics by adding the type of the metrics into a set, defaults to an empty set.
+Available Types : `NET_SERVER`, `NET_CLIENT`, `HTTP_SERVER`, `HTTP_CLIENT`, `DATAGRAM_SOCKET`, `EVENT_BUS`.
+<9> Add your `VertxHawkularOptions` to the `io.vertx.core.VertxOptions`
+<10> Create the Vert.x instance
 
 == Limitations
 

--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -68,6 +68,11 @@ Set the maximum number of metrics in a batch. To reduce the number of HTTP excha
  Hawkular server in batches. A batch is sent as soon as the number of metrics collected reaches the configured
  <code>batchSize</code>, or after the <code>batchDelay</code> expires. Defaults to <code>50</code>.
 +++
+|[[disabledMetricsType]]`disabledMetricsType`|`link:enums.html#MetricsTypeEnum[MetricsTypeEnum]`|
++++
+Set metric that will not be registered. Schedulers will check the set <code>disabledMetricsTypes</code> when
+ registering metrics suppliers
++++
 |[[enabled]]`enabled`|`Boolean`|
 +++
 Set whether metrics will be enabled on the Vert.x instance. Metrics are not enabled by default.

--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -68,7 +68,7 @@ Set the maximum number of metrics in a batch. To reduce the number of HTTP excha
  Hawkular server in batches. A batch is sent as soon as the number of metrics collected reaches the configured
  <code>batchSize</code>, or after the <code>batchDelay</code> expires. Defaults to <code>50</code>.
 +++
-|[[disabledMetricsType]]`disabledMetricsType`|`link:enums.html#MetricsTypeEnum[MetricsTypeEnum]`|
+|[[disabledMetricsType]]`disabledMetricsType`|`link:enums.html#MetricsType[MetricsType]`|
 +++
 Set metric that will not be registered. Schedulers will check the set <code>disabledMetricsTypes</code> when
  registering metrics suppliers

--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -68,10 +68,9 @@ Set the maximum number of metrics in a batch. To reduce the number of HTTP excha
  Hawkular server in batches. A batch is sent as soon as the number of metrics collected reaches the configured
  <code>batchSize</code>, or after the <code>batchDelay</code> expires. Defaults to <code>50</code>.
 +++
-|[[disabledMetricsType]]`disabledMetricsType`|`link:enums.html#MetricsType[MetricsType]`|
+|[[disabledMetricsTypes]]`disabledMetricsTypes`|`Array of link:enums.html#MetricsType[MetricsType]`|
 +++
-Set metric that will not be registered. Schedulers will check the set <code>disabledMetricsTypes</code> when
- registering metrics suppliers
+Sets metrics types that are disabled.
 +++
 |[[enabled]]`enabled`|`Boolean`|
 +++

--- a/src/main/asciidoc/enums.adoc
+++ b/src/main/asciidoc/enums.adoc
@@ -32,6 +32,10 @@ Type for http client metrics
 +++
 Type for datagram socket metrics
 +++
+|[[EVENT_BUS]]`EVENT_BUS`|
++++
+Type for event bus metrics
++++
 |===
 
 [[ServerType]]

--- a/src/main/asciidoc/enums.adoc
+++ b/src/main/asciidoc/enums.adoc
@@ -12,23 +12,23 @@
 [frame="topbot"]
 |===
 ^|Name | Description
-|[[NET_SERVER_TYPE]]`NET_SERVER_TYPE`|
+|[[NET_SERVER]]`NET_SERVER`|
 +++
 Type for net server metrics
 +++
-|[[NET_CLIENT_TYPE]]`NET_CLIENT_TYPE`|
+|[[NET_CLIENT]]`NET_CLIENT`|
 +++
 Type for net client metrics
 +++
-|[[HTTP_SERVER_TYPE]]`HTTP_SERVER_TYPE`|
+|[[HTTP_SERVER]]`HTTP_SERVER`|
 +++
 Type for http server metrics
 +++
-|[[HTTP_CLIENT_TYPE]]`HTTP_CLIENT_TYPE`|
+|[[HTTP_CLIENT]]`HTTP_CLIENT`|
 +++
 Type for http client metrics
 +++
-|[[DATAGRAM_SOCKET_TYPE]]`DATAGRAM_SOCKET_TYPE`|
+|[[DATAGRAM_SOCKET]]`DATAGRAM_SOCKET`|
 +++
 Type for datagram socket metrics
 +++

--- a/src/main/asciidoc/enums.adoc
+++ b/src/main/asciidoc/enums.adoc
@@ -1,7 +1,7 @@
 = Enums
 
-[[MetricsTypeEnum]]
-== MetricsTypeEnum
+[[MetricsType]]
+== MetricsType
 
 ++++
   Metrics types for each metrics.

--- a/src/main/asciidoc/enums.adoc
+++ b/src/main/asciidoc/enums.adoc
@@ -1,5 +1,39 @@
 = Enums
 
+[[MetricsTypeEnum]]
+== MetricsTypeEnum
+
+++++
+  Metrics types for each metrics.
+++++
+'''
+
+[cols=">25%,75%"]
+[frame="topbot"]
+|===
+^|Name | Description
+|[[NET_SERVER_TYPE]]`NET_SERVER_TYPE`|
++++
+Type for net server metrics
++++
+|[[NET_CLIENT_TYPE]]`NET_CLIENT_TYPE`|
++++
+Type for net client metrics
++++
+|[[HTTP_SERVER_TYPE]]`HTTP_SERVER_TYPE`|
++++
+Type for http server metrics
++++
+|[[HTTP_CLIENT_TYPE]]`HTTP_CLIENT_TYPE`|
++++
+Type for http client metrics
++++
+|[[DATAGRAM_SOCKET_TYPE]]`DATAGRAM_SOCKET_TYPE`|
++++
+Type for datagram socket metrics
++++
+|===
+
 [[ServerType]]
 == ServerType
 

--- a/src/main/generated/io/vertx/ext/hawkular/VertxHawkularOptionsConverter.java
+++ b/src/main/generated/io/vertx/ext/hawkular/VertxHawkularOptionsConverter.java
@@ -33,6 +33,9 @@ public class VertxHawkularOptionsConverter {
     if (json.getValue("batchSize") instanceof Number) {
       obj.setBatchSize(((Number)json.getValue("batchSize")).intValue());
     }
+    if (json.getValue("disabledMetricsType") instanceof String) {
+      obj.setDisabledMetricsType(io.vertx.ext.hawkular.MetricsTypeEnum.valueOf((String)json.getValue("disabledMetricsType")));
+    }
     if (json.getValue("enabled") instanceof Boolean) {
       obj.setEnabled((Boolean)json.getValue("enabled"));
     }

--- a/src/main/generated/io/vertx/ext/hawkular/VertxHawkularOptionsConverter.java
+++ b/src/main/generated/io/vertx/ext/hawkular/VertxHawkularOptionsConverter.java
@@ -33,8 +33,11 @@ public class VertxHawkularOptionsConverter {
     if (json.getValue("batchSize") instanceof Number) {
       obj.setBatchSize(((Number)json.getValue("batchSize")).intValue());
     }
-    if (json.getValue("disabledMetricsType") instanceof String) {
-      obj.setDisabledMetricsType(io.vertx.ext.hawkular.MetricsType.valueOf((String)json.getValue("disabledMetricsType")));
+    if (json.getValue("disabledMetricsTypes") instanceof JsonArray) {
+      json.getJsonArray("disabledMetricsTypes").forEach(item -> {
+        if (item instanceof String)
+          obj.addDisabledMetricsType(io.vertx.ext.hawkular.MetricsType.valueOf((String)item));
+      });
     }
     if (json.getValue("enabled") instanceof Boolean) {
       obj.setEnabled((Boolean)json.getValue("enabled"));
@@ -77,6 +80,13 @@ public class VertxHawkularOptionsConverter {
   public static void toJson(VertxHawkularOptions obj, JsonObject json) {
     json.put("batchDelay", obj.getBatchDelay());
     json.put("batchSize", obj.getBatchSize());
+    if (obj.getDisabledMetricsTypes() != null) {
+      json.put("disabledMetricsTypes", new JsonArray(
+          obj.getDisabledMetricsTypes().
+              stream().
+              map(item -> item.name()).
+              collect(java.util.stream.Collectors.toList())));
+    }
     json.put("enabled", obj.isEnabled());
     if (obj.getHost() != null) {
       json.put("host", obj.getHost());

--- a/src/main/generated/io/vertx/ext/hawkular/VertxHawkularOptionsConverter.java
+++ b/src/main/generated/io/vertx/ext/hawkular/VertxHawkularOptionsConverter.java
@@ -34,7 +34,7 @@ public class VertxHawkularOptionsConverter {
       obj.setBatchSize(((Number)json.getValue("batchSize")).intValue());
     }
     if (json.getValue("disabledMetricsType") instanceof String) {
-      obj.setDisabledMetricsType(io.vertx.ext.hawkular.MetricsTypeEnum.valueOf((String)json.getValue("disabledMetricsType")));
+      obj.setDisabledMetricsType(io.vertx.ext.hawkular.MetricsType.valueOf((String)json.getValue("disabledMetricsType")));
     }
     if (json.getValue("enabled") instanceof Boolean) {
       obj.setEnabled((Boolean)json.getValue("enabled"));

--- a/src/main/java/io/vertx/ext/hawkular/MetricsType.java
+++ b/src/main/java/io/vertx/ext/hawkular/MetricsType.java
@@ -22,30 +22,30 @@ import io.vertx.codegen.annotations.VertxGen;
  *  Metrics types for each metrics.
  */
 @VertxGen
-public enum MetricsTypeEnum {
+public enum MetricsType {
 
   /**
    * Type for net server metrics
    */
-  NET_SERVER_TYPE,
+  NET_SERVER,
   /**
    * Type for net client metrics
    */
-  NET_CLIENT_TYPE,
+  NET_CLIENT,
   /**
    * Type for http server metrics
    */
-  HTTP_SERVER_TYPE,
+  HTTP_SERVER,
   /**
    * Type for http client metrics
    */
-  HTTP_CLIENT_TYPE,
+  HTTP_CLIENT,
   /**
    * Type for datagram socket metrics
    */
-  DATAGRAM_SOCKET_TYPE,
+  DATAGRAM_SOCKET,
   /**
    * Type for event bus metrics
    */
-  EVENT_BUS_TYPE
+  EVENT_BUS
 }

--- a/src/main/java/io/vertx/ext/hawkular/MetricsTypeEnum.java
+++ b/src/main/java/io/vertx/ext/hawkular/MetricsTypeEnum.java
@@ -24,28 +24,28 @@ import io.vertx.codegen.annotations.VertxGen;
 @VertxGen
 public enum MetricsTypeEnum {
 
-    /**
-     * Type for net server metrics
-     */
-    NET_SERVER_TYPE,
-    /**
-     * Type for net client metrics
-     */
-    NET_CLIENT_TYPE,
-    /**
-     * Type for http server metrics
-     */
-    HTTP_SERVER_TYPE,
-    /**
-     * Type for http client metrics
-     */
-    HTTP_CLIENT_TYPE,
-    /**
-     * Type for datagram socket metrics
-     */
-    DATAGRAM_SOCKET_TYPE,
-    /**
-     * Type for event bus metrics
-     */
-    EVENT_BUS_TYPE
+  /**
+   * Type for net server metrics
+   */
+  NET_SERVER_TYPE,
+  /**
+   * Type for net client metrics
+   */
+  NET_CLIENT_TYPE,
+  /**
+   * Type for http server metrics
+   */
+  HTTP_SERVER_TYPE,
+  /**
+   * Type for http client metrics
+   */
+  HTTP_CLIENT_TYPE,
+  /**
+   * Type for datagram socket metrics
+   */
+  DATAGRAM_SOCKET_TYPE,
+  /**
+   * Type for event bus metrics
+   */
+  EVENT_BUS_TYPE
 }

--- a/src/main/java/io/vertx/ext/hawkular/MetricsTypeEnum.java
+++ b/src/main/java/io/vertx/ext/hawkular/MetricsTypeEnum.java
@@ -1,4 +1,7 @@
 package io.vertx.ext.hawkular;
+
+import io.vertx.codegen.annotations.VertxGen;
+
 /*
  * Copyright 2015 Red Hat, Inc.
  *
@@ -14,6 +17,35 @@ package io.vertx.ext.hawkular;
  *
  *  You may elect to redistribute this code under either of these licenses.
  */
+
+/**
+ *  Metrics types for each metrics.
+ */
+@VertxGen
 public enum MetricsTypeEnum {
-    NET_SERVER_TYPE, NET_CLIENT_TYPE, HTTP_SERVER_TYPE, HTTP_CLIENT_TYPE, DATAGRAM_SOCKET_TYPE, EVENT_BUS_TYPE
+
+    /**
+     * Type for net server metrics
+     */
+    NET_SERVER_TYPE,
+    /**
+     * Type for net client metrics
+     */
+    NET_CLIENT_TYPE,
+    /**
+     * Type for http server metrics
+     */
+    HTTP_SERVER_TYPE,
+    /**
+     * Type for http client metrics
+     */
+    HTTP_CLIENT_TYPE,
+    /**
+     * Type for datagram socket metrics
+     */
+    DATAGRAM_SOCKET_TYPE,
+    /**
+     * Type for event bus metrics
+     */
+    EVENT_BUS_TYPE
 }

--- a/src/main/java/io/vertx/ext/hawkular/MetricsTypeEnum.java
+++ b/src/main/java/io/vertx/ext/hawkular/MetricsTypeEnum.java
@@ -1,0 +1,19 @@
+package io.vertx.ext.hawkular;
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+public enum MetricsTypeEnum {
+    NET_SERVER_TYPE, NET_CLIENT_TYPE, HTTP_SERVER_TYPE, HTTP_CLIENT_TYPE, DATAGRAM_SOCKET_TYPE, EVENT_BUS_TYPE
+}

--- a/src/main/java/io/vertx/ext/hawkular/MetricsTypeEnum.java
+++ b/src/main/java/io/vertx/ext/hawkular/MetricsTypeEnum.java
@@ -1,7 +1,3 @@
-package io.vertx.ext.hawkular;
-
-import io.vertx.codegen.annotations.VertxGen;
-
 /*
  * Copyright 2015 Red Hat, Inc.
  *
@@ -17,6 +13,10 @@ import io.vertx.codegen.annotations.VertxGen;
  *
  *  You may elect to redistribute this code under either of these licenses.
  */
+package io.vertx.ext.hawkular;
+
+import io.vertx.codegen.annotations.VertxGen;
+
 
 /**
  *  Metrics types for each metrics.

--- a/src/main/java/io/vertx/ext/hawkular/VertxHawkularOptions.java
+++ b/src/main/java/io/vertx/ext/hawkular/VertxHawkularOptions.java
@@ -22,6 +22,9 @@ import io.vertx.core.metrics.MetricsOptions;
 
 import static io.vertx.ext.hawkular.ServerType.*;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * Vert.x Hawkular monitoring configuration.
  *
@@ -93,6 +96,7 @@ public class VertxHawkularOptions extends MetricsOptions {
   private int batchDelay;
   private boolean metricsBridgeEnabled;
   private String metricsBridgeAddress;
+  private Set<MetricsTypeEnum> disabledMetricsTypes;
 
   public VertxHawkularOptions() {
     host = DEFAULT_HOST;
@@ -108,6 +112,7 @@ public class VertxHawkularOptions extends MetricsOptions {
     batchDelay = DEFAULT_BATCH_DELAY;
     metricsBridgeEnabled = DEFAULT_METRICS_BRIDGE_ENABLED;
     metricsBridgeAddress = DEFAULT_METRICS_BRIDGE_ADDRESS;
+    disabledMetricsTypes = new HashSet<>();
   }
 
   public VertxHawkularOptions(VertxHawkularOptions other) {
@@ -355,5 +360,20 @@ public class VertxHawkularOptions extends MetricsOptions {
   public VertxHawkularOptions setMetricsBridgeEnabled(boolean metricsBridgeEnabled) {
     this.metricsBridgeEnabled = metricsBridgeEnabled;
     return this;
+  }
+  /**
+   * Set metric that will not be registered. Schedulers will check the set {@code disabledMetricsTypes} when
+   * registering metrics suppliers
+   *
+   * @param metricsType the type of metrics
+   * @return the current {@link VertxHawkularOptions} instance
+   */
+  public VertxHawkularOptions disabledMetricsType(MetricsTypeEnum metricsType) {
+    this.disabledMetricsTypes.add(metricsType);
+    return this;
+  }
+
+  public boolean isMetricsTypeDisabled(MetricsTypeEnum metricsType) {
+    return this.disabledMetricsTypes.contains(metricsType);
   }
 }

--- a/src/main/java/io/vertx/ext/hawkular/VertxHawkularOptions.java
+++ b/src/main/java/io/vertx/ext/hawkular/VertxHawkularOptions.java
@@ -362,6 +362,23 @@ public class VertxHawkularOptions extends MetricsOptions {
     this.metricsBridgeEnabled = metricsBridgeEnabled;
     return this;
   }
+
+  /**
+   * @return the disabled metrics types.
+   */
+  public Set<MetricsType> getDisabledMetricsTypes() {
+    return disabledMetricsTypes;
+  }
+
+  /**
+   * Sets metrics types that are disabled.
+   *
+   * @param disabledMetricsTypes to specify the set of metrics types to be disabled.
+   */
+  public void setDisabledMetricsTypes(Set<MetricsType> disabledMetricsTypes) {
+    this.disabledMetricsTypes = disabledMetricsTypes;
+  }
+
   /**
    * Set metric that will not be registered. Schedulers will check the set {@code disabledMetricsTypes} when
    * registering metrics suppliers

--- a/src/main/java/io/vertx/ext/hawkular/VertxHawkularOptions.java
+++ b/src/main/java/io/vertx/ext/hawkular/VertxHawkularOptions.java
@@ -22,7 +22,7 @@ import io.vertx.core.metrics.MetricsOptions;
 
 import static io.vertx.ext.hawkular.ServerType.*;
 
-import java.util.HashSet;
+import java.util.EnumSet;
 import java.util.Set;
 
 /**
@@ -112,7 +112,7 @@ public class VertxHawkularOptions extends MetricsOptions {
     batchDelay = DEFAULT_BATCH_DELAY;
     metricsBridgeEnabled = DEFAULT_METRICS_BRIDGE_ENABLED;
     metricsBridgeAddress = DEFAULT_METRICS_BRIDGE_ADDRESS;
-    disabledMetricsTypes = new HashSet<>();
+    disabledMetricsTypes = EnumSet.noneOf(MetricsTypeEnum.class);
   }
 
   public VertxHawkularOptions(VertxHawkularOptions other) {
@@ -368,7 +368,7 @@ public class VertxHawkularOptions extends MetricsOptions {
    * @param metricsType the type of metrics
    * @return the current {@link VertxHawkularOptions} instance
    */
-  public VertxHawkularOptions disabledMetricsType(MetricsTypeEnum metricsType) {
+  public VertxHawkularOptions setDisabledMetricsType(MetricsTypeEnum metricsType) {
     this.disabledMetricsTypes.add(metricsType);
     return this;
   }

--- a/src/main/java/io/vertx/ext/hawkular/VertxHawkularOptions.java
+++ b/src/main/java/io/vertx/ext/hawkular/VertxHawkularOptions.java
@@ -130,6 +130,7 @@ public class VertxHawkularOptions extends MetricsOptions {
     batchDelay = other.batchDelay;
     metricsBridgeAddress = other.metricsBridgeAddress;
     metricsBridgeEnabled = other.metricsBridgeEnabled;
+    disabledMetricsTypes = other.disabledMetricsTypes != null ? other.disabledMetricsTypes : EnumSet.noneOf(MetricsTypeEnum.class);
   }
 
   public VertxHawkularOptions(JsonObject json) {

--- a/src/main/java/io/vertx/ext/hawkular/VertxHawkularOptions.java
+++ b/src/main/java/io/vertx/ext/hawkular/VertxHawkularOptions.java
@@ -96,7 +96,7 @@ public class VertxHawkularOptions extends MetricsOptions {
   private int batchDelay;
   private boolean metricsBridgeEnabled;
   private String metricsBridgeAddress;
-  private Set<MetricsTypeEnum> disabledMetricsTypes;
+  private Set<MetricsType> disabledMetricsTypes;
 
   public VertxHawkularOptions() {
     host = DEFAULT_HOST;
@@ -112,7 +112,7 @@ public class VertxHawkularOptions extends MetricsOptions {
     batchDelay = DEFAULT_BATCH_DELAY;
     metricsBridgeEnabled = DEFAULT_METRICS_BRIDGE_ENABLED;
     metricsBridgeAddress = DEFAULT_METRICS_BRIDGE_ADDRESS;
-    disabledMetricsTypes = EnumSet.noneOf(MetricsTypeEnum.class);
+    disabledMetricsTypes = EnumSet.noneOf(MetricsType.class);
   }
 
   public VertxHawkularOptions(VertxHawkularOptions other) {
@@ -130,7 +130,7 @@ public class VertxHawkularOptions extends MetricsOptions {
     batchDelay = other.batchDelay;
     metricsBridgeAddress = other.metricsBridgeAddress;
     metricsBridgeEnabled = other.metricsBridgeEnabled;
-    disabledMetricsTypes = other.disabledMetricsTypes != null ? EnumSet.copyOf(other.disabledMetricsTypes) : EnumSet.noneOf(MetricsTypeEnum.class);
+    disabledMetricsTypes = other.disabledMetricsTypes != null ? EnumSet.copyOf(other.disabledMetricsTypes) : EnumSet.noneOf(MetricsType.class);
   }
 
   public VertxHawkularOptions(JsonObject json) {
@@ -369,12 +369,12 @@ public class VertxHawkularOptions extends MetricsOptions {
    * @param metricsType the type of metrics
    * @return the current {@link VertxHawkularOptions} instance
    */
-  public VertxHawkularOptions setDisabledMetricsType(MetricsTypeEnum metricsType) {
+  public VertxHawkularOptions setDisabledMetricsType(MetricsType metricsType) {
     this.disabledMetricsTypes.add(metricsType);
     return this;
   }
 
-  public boolean isMetricsTypeDisabled(MetricsTypeEnum metricsType) {
+  public boolean isMetricsTypeDisabled(MetricsType metricsType) {
     return this.disabledMetricsTypes.contains(metricsType);
   }
 }

--- a/src/main/java/io/vertx/ext/hawkular/VertxHawkularOptions.java
+++ b/src/main/java/io/vertx/ext/hawkular/VertxHawkularOptions.java
@@ -386,7 +386,7 @@ public class VertxHawkularOptions extends MetricsOptions {
    * @param metricsType the type of metrics
    * @return the current {@link VertxHawkularOptions} instance
    */
-  public VertxHawkularOptions setDisabledMetricsType(MetricsType metricsType) {
+  public VertxHawkularOptions addDisabledMetricsType(MetricsType metricsType) {
     this.disabledMetricsTypes.add(metricsType);
     return this;
   }

--- a/src/main/java/io/vertx/ext/hawkular/VertxHawkularOptions.java
+++ b/src/main/java/io/vertx/ext/hawkular/VertxHawkularOptions.java
@@ -130,7 +130,7 @@ public class VertxHawkularOptions extends MetricsOptions {
     batchDelay = other.batchDelay;
     metricsBridgeAddress = other.metricsBridgeAddress;
     metricsBridgeEnabled = other.metricsBridgeEnabled;
-    disabledMetricsTypes = other.disabledMetricsTypes != null ? other.disabledMetricsTypes : EnumSet.noneOf(MetricsTypeEnum.class);
+    disabledMetricsTypes = other.disabledMetricsTypes != null ? EnumSet.copyOf(other.disabledMetricsTypes) : EnumSet.noneOf(MetricsTypeEnum.class);
   }
 
   public VertxHawkularOptions(JsonObject json) {

--- a/src/main/java/io/vertx/ext/hawkular/impl/VertxMetricsImpl.java
+++ b/src/main/java/io/vertx/ext/hawkular/impl/VertxMetricsImpl.java
@@ -39,7 +39,7 @@ import io.vertx.core.spi.metrics.EventBusMetrics;
 import io.vertx.core.spi.metrics.HttpClientMetrics;
 import io.vertx.core.spi.metrics.HttpServerMetrics;
 import io.vertx.core.spi.metrics.TCPMetrics;
-import io.vertx.ext.hawkular.MetricsTypeEnum;
+import io.vertx.ext.hawkular.MetricsType;
 import io.vertx.ext.hawkular.VertxHawkularOptions;
 
 /**
@@ -122,17 +122,17 @@ public class VertxMetricsImpl extends DummyVertxMetrics {
     Context context = vertx.getOrCreateContext();
     sender = new Sender(vertx, options, context);
     scheduler = new Scheduler(vertx, options, context, sender);
-    if(this.options.isMetricsTypeDisabled(MetricsTypeEnum.HTTP_SERVER_TYPE))
+    if(this.options.isMetricsTypeDisabled(MetricsType.HTTP_SERVER))
       scheduler.register(httpServerMetricsSupplier);
-    if(this.options.isMetricsTypeDisabled(MetricsTypeEnum.HTTP_CLIENT_TYPE))
+    if(this.options.isMetricsTypeDisabled(MetricsType.HTTP_CLIENT))
       scheduler.register(httpClientMetricsSupplier);
-    if(this.options.isMetricsTypeDisabled(MetricsTypeEnum.NET_SERVER_TYPE))
+    if(this.options.isMetricsTypeDisabled(MetricsType.NET_SERVER))
       scheduler.register(netServerMetricsSupplier);
-    if(this.options.isMetricsTypeDisabled(MetricsTypeEnum.NET_CLIENT_TYPE))
+    if(this.options.isMetricsTypeDisabled(MetricsType.NET_CLIENT))
       scheduler.register(netClientMetricsSupplier);
-    if(this.options.isMetricsTypeDisabled(MetricsTypeEnum.DATAGRAM_SOCKET_TYPE))
+    if(this.options.isMetricsTypeDisabled(MetricsType.DATAGRAM_SOCKET))
       scheduler.register(datagramSocketMetricsSupplier);
-    if(this.options.isMetricsTypeDisabled(MetricsTypeEnum.EVENT_BUS_TYPE))
+    if(this.options.isMetricsTypeDisabled(MetricsType.EVENT_BUS))
       scheduler.register(eventBusMetrics);
 
     //Configure the metrics bridge. It just transforms the received metrics (json) to a Single Metric to enqueue it.

--- a/src/main/java/io/vertx/ext/hawkular/impl/VertxMetricsImpl.java
+++ b/src/main/java/io/vertx/ext/hawkular/impl/VertxMetricsImpl.java
@@ -122,17 +122,17 @@ public class VertxMetricsImpl extends DummyVertxMetrics {
     Context context = vertx.getOrCreateContext();
     sender = new Sender(vertx, options, context);
     scheduler = new Scheduler(vertx, options, context, sender);
-    if(this.options.isMetricsTypeDisabled(MetricsType.HTTP_SERVER))
+    if(!this.options.isMetricsTypeDisabled(MetricsType.HTTP_SERVER))
       scheduler.register(httpServerMetricsSupplier);
-    if(this.options.isMetricsTypeDisabled(MetricsType.HTTP_CLIENT))
+    if(!this.options.isMetricsTypeDisabled(MetricsType.HTTP_CLIENT))
       scheduler.register(httpClientMetricsSupplier);
-    if(this.options.isMetricsTypeDisabled(MetricsType.NET_SERVER))
+    if(!this.options.isMetricsTypeDisabled(MetricsType.NET_SERVER))
       scheduler.register(netServerMetricsSupplier);
-    if(this.options.isMetricsTypeDisabled(MetricsType.NET_CLIENT))
+    if(!this.options.isMetricsTypeDisabled(MetricsType.NET_CLIENT))
       scheduler.register(netClientMetricsSupplier);
-    if(this.options.isMetricsTypeDisabled(MetricsType.DATAGRAM_SOCKET))
+    if(!this.options.isMetricsTypeDisabled(MetricsType.DATAGRAM_SOCKET))
       scheduler.register(datagramSocketMetricsSupplier);
-    if(this.options.isMetricsTypeDisabled(MetricsType.EVENT_BUS))
+    if(!this.options.isMetricsTypeDisabled(MetricsType.EVENT_BUS))
       scheduler.register(eventBusMetrics);
 
     //Configure the metrics bridge. It just transforms the received metrics (json) to a Single Metric to enqueue it.

--- a/src/main/java/io/vertx/ext/hawkular/impl/VertxMetricsImpl.java
+++ b/src/main/java/io/vertx/ext/hawkular/impl/VertxMetricsImpl.java
@@ -39,6 +39,7 @@ import io.vertx.core.spi.metrics.EventBusMetrics;
 import io.vertx.core.spi.metrics.HttpClientMetrics;
 import io.vertx.core.spi.metrics.HttpServerMetrics;
 import io.vertx.core.spi.metrics.TCPMetrics;
+import io.vertx.ext.hawkular.MetricsTypeEnum;
 import io.vertx.ext.hawkular.VertxHawkularOptions;
 
 /**
@@ -121,12 +122,18 @@ public class VertxMetricsImpl extends DummyVertxMetrics {
     Context context = vertx.getOrCreateContext();
     sender = new Sender(vertx, options, context);
     scheduler = new Scheduler(vertx, options, context, sender);
-    scheduler.register(httpServerMetricsSupplier);
-    scheduler.register(httpClientMetricsSupplier);
-    scheduler.register(netServerMetricsSupplier);
-    scheduler.register(netClientMetricsSupplier);
-    scheduler.register(datagramSocketMetricsSupplier);
-    scheduler.register(eventBusMetrics);
+    if(this.options.isMetricsTypeDisabled(MetricsTypeEnum.HTTP_SERVER_TYPE))
+      scheduler.register(httpServerMetricsSupplier);
+    if(this.options.isMetricsTypeDisabled(MetricsTypeEnum.HTTP_CLIENT_TYPE))
+      scheduler.register(httpClientMetricsSupplier);
+    if(this.options.isMetricsTypeDisabled(MetricsTypeEnum.NET_SERVER_TYPE))
+      scheduler.register(netServerMetricsSupplier);
+    if(this.options.isMetricsTypeDisabled(MetricsTypeEnum.NET_CLIENT_TYPE))
+      scheduler.register(netClientMetricsSupplier);
+    if(this.options.isMetricsTypeDisabled(MetricsTypeEnum.DATAGRAM_SOCKET_TYPE))
+      scheduler.register(datagramSocketMetricsSupplier);
+    if(this.options.isMetricsTypeDisabled(MetricsTypeEnum.EVENT_BUS_TYPE))
+      scheduler.register(eventBusMetrics);
 
     //Configure the metrics bridge. It just transforms the received metrics (json) to a Single Metric to enqueue it.
     if (options.isMetricsBridgeEnabled() && options.getMetricsBridgeAddress() != null) {


### PR DESCRIPTION
Hi, I come up with this naive solution.
An enum indicates all metrics and a set that holds the enum which are disabled metrics.
