### PR TITLE
Fixes #23 Implement HTTP2 Metrics

### DIFF
--- a/src/main/java/io/vertx/ext/hawkular/impl/HttpClientConnectionsMeasurements.java
+++ b/src/main/java/io/vertx/ext/hawkular/impl/HttpClientConnectionsMeasurements.java
@@ -16,9 +16,9 @@
 
 package io.vertx.ext.hawkular.impl;
 
-import java.util.concurrent.atomic.LongAdder;
-
 import static java.util.concurrent.TimeUnit.*;
+
+import java.util.concurrent.atomic.LongAdder;
 
 /**
  * Holds measurements for all connections of a {@link io.vertx.core.http.HttpClient} to a remote
@@ -74,6 +74,13 @@ public class HttpClientConnectionsMeasurements {
   public void requestBegin() {
     requests.increment();
     requestCount.increment();
+  }
+
+  /**
+   * Signal a request couldn't complete successfully.
+   */
+  public void requestReset() {
+    requests.decrement();
   }
 
   /**

--- a/src/main/java/io/vertx/ext/hawkular/impl/HttpClientMetricsImpl.java
+++ b/src/main/java/io/vertx/ext/hawkular/impl/HttpClientMetricsImpl.java
@@ -55,12 +55,16 @@ public class HttpClientMetricsImpl implements HttpClientMetrics<HttpClientReques
   }
 
   @Override
-  public HttpClientRequestMetrics responsePushed(SocketAddress socketMetric, SocketAddress localAddress, SocketAddress remoteAddress, HttpClientRequest request) {
-    return null;
+  public HttpClientRequestMetrics responsePushed(SocketAddress key, SocketAddress localAddress, SocketAddress remoteAddress, HttpClientRequest request) {
+    return requestBegin(key, localAddress, remoteAddress, request);
   }
 
   @Override
   public void requestReset(HttpClientRequestMetrics requestMetric) {
+    HttpClientConnectionsMeasurements measurements = connectionsMeasurements.get(requestMetric.getAddress());
+    if (measurements != null) {
+      measurements.requestReset();
+    }
   }
 
   @Override

--- a/src/main/java/io/vertx/ext/hawkular/impl/HttpServerMetricsImpl.java
+++ b/src/main/java/io/vertx/ext/hawkular/impl/HttpServerMetricsImpl.java
@@ -61,11 +61,14 @@ public class HttpServerMetricsImpl implements HttpServerMetrics<Long, Void, Void
 
   @Override
   public void requestReset(Long requestMetric) {
+    requestCount.increment();
+    requests.decrement();
   }
 
   @Override
   public Long responsePushed(Void socketMetric, HttpMethod method, String uri, HttpServerResponse response) {
-    return null;
+    requests.increment();
+    return System.nanoTime();
   }
 
   @Override


### PR DESCRIPTION
Strictly speaking, this isn't about HTTP2 Metrics. It's about adapting to the HTTP Metrics changes following HTTP2 implementation.

We need to treat #requestPushed callback as a #requestBegin one. And decrement request counters if needed in #requestReset.
