### PR TITLE
Fixes #28 Tenant selection with Hawkular Alpha13 and up

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -18,11 +18,16 @@ Set the identifier used for authentication.
 +++
 |[[persona]]`persona`|`String`|
 +++
-Set the Hawkular Persona identifier. This is used to impersonate an organization with user credentials.
+DEPRECATED. Do not use with Hawkular Alpha13 and up.
+ Set the Hawkular Persona identifier. This is used to impersonate an organization with user credentials.
 +++
 |[[secret]]`secret`|`String`|
 +++
 Set the secret used for authentication.
++++
+|[[tenant]]`tenant`|`String`|
++++
+Set the Hawkular tenant. Defaults to <code>hawkular</code>.
 +++
 |===
 

--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -102,7 +102,7 @@ def vertx = Vertx.vertx([
 
 ----
 
-==== Authentication with a Hawkular server
+==== Tenant selection and authentication with a Hawkular server
 
 Requests sent to an Hawkular server must be authenticated:
 
@@ -116,12 +116,15 @@ def vertx = Vertx.vertx([
     serverType:ServerType.HAWKULAR,
     hawkularServerOptions:[
       id:"username",
-      secret:"password"
+      secret:"password",
+      tenant:"sales-department"
     ]
   ]
 ])
 
 ----
+
+The tenant option may be omitted, and will default to `hawkular`.
 
 === HTTPS and other HTTP related options
 

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -86,7 +86,7 @@ Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(
 ));
 ----
 
-==== Authentication with a Hawkular server
+==== Tenant selection and authentication with a Hawkular server
 
 Requests sent to an Hawkular server must be authenticated:
 
@@ -100,9 +100,12 @@ Vertx vertx = Vertx.vertx(new VertxOptions().setMetricsOptions(
       new HawkularServerOptions()
         .setId("username")
         .setSecret("password")
+        .setTenant("sales-department")
     )
 ));
 ----
+
+The tenant option may be omitted, and will default to `hawkular`.
 
 === HTTPS and other HTTP related options
 

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -101,7 +101,7 @@ var vertx = Vertx.vertx({
 
 ----
 
-==== Authentication with a Hawkular server
+==== Tenant selection and authentication with a Hawkular server
 
 Requests sent to an Hawkular server must be authenticated:
 
@@ -114,12 +114,15 @@ var vertx = Vertx.vertx({
     "serverType" : 'HAWKULAR',
     "hawkularServerOptions" : {
       "id" : "username",
-      "secret" : "password"
+      "secret" : "password",
+      "tenant" : "sales-department"
     }
   }
 });
 
 ----
+
+The tenant option may be omitted, and will default to `hawkular`.
 
 === HTTPS and other HTTP related options
 

--- a/src/main/asciidoc/ruby/index.adoc
+++ b/src/main/asciidoc/ruby/index.adoc
@@ -101,7 +101,7 @@ vertx = Vertx::Vertx.vertx({
 
 ----
 
-==== Authentication with a Hawkular server
+==== Tenant selection and authentication with a Hawkular server
 
 Requests sent to an Hawkular server must be authenticated:
 
@@ -114,12 +114,15 @@ vertx = Vertx::Vertx.vertx({
     'serverType' => :HAWKULAR,
     'hawkularServerOptions' => {
       'id' => "username",
-      'secret' => "password"
+      'secret' => "password",
+      'tenant' => "sales-department"
     }
   }
 })
 
 ----
+
+The tenant option may be omitted, and will default to `hawkular`.
 
 === HTTPS and other HTTP related options
 

--- a/src/main/generated/io/vertx/ext/hawkular/HawkularServerOptionsConverter.java
+++ b/src/main/generated/io/vertx/ext/hawkular/HawkularServerOptionsConverter.java
@@ -36,6 +36,9 @@ public class HawkularServerOptionsConverter {
     if (json.getValue("secret") instanceof String) {
       obj.setSecret((String)json.getValue("secret"));
     }
+    if (json.getValue("tenant") instanceof String) {
+      obj.setTenant((String)json.getValue("tenant"));
+    }
   }
 
   public static void toJson(HawkularServerOptions obj, JsonObject json) {
@@ -47,6 +50,9 @@ public class HawkularServerOptionsConverter {
     }
     if (obj.getSecret() != null) {
       json.put("secret", obj.getSecret());
+    }
+    if (obj.getTenant() != null) {
+      json.put("tenant", obj.getTenant());
     }
   }
 }

--- a/src/main/java/examples/MetricsExamples.java
+++ b/src/main/java/examples/MetricsExamples.java
@@ -74,6 +74,7 @@ public class MetricsExamples {
           new HawkularServerOptions()
             .setId("username")
             .setSecret("password")
+            .setTenant("sales-department")
         )
     ));
   }

--- a/src/main/java/io/vertx/ext/hawkular/HawkularServerOptions.java
+++ b/src/main/java/io/vertx/ext/hawkular/HawkularServerOptions.java
@@ -26,18 +26,26 @@ import io.vertx.core.json.JsonObject;
  */
 @DataObject(generateConverter = true)
 public class HawkularServerOptions {
+  /**
+   * The default Hawkular tenant = hawkular.
+   */
+  public static final String DEFAULT_TENANT = "hawkular";
 
   private String id;
   private String secret;
+  @Deprecated
   private String persona;
+  private String tenant;
 
   public HawkularServerOptions() {
+    this.tenant = DEFAULT_TENANT;
   }
 
   public HawkularServerOptions(HawkularServerOptions other) {
     id = other.id;
     secret = other.secret;
     persona = other.persona;
+    tenant = other.tenant;
   }
 
   public HawkularServerOptions(JsonObject json) {
@@ -76,16 +84,38 @@ public class HawkularServerOptions {
 
   /**
    * @return the Hawkular Persona identifier
+   * @deprecated
+   * @see #setPersona(String)
    */
+  @Deprecated
   public String getPersona() {
     return persona;
   }
 
   /**
+   * DEPRECATED. Do not use with Hawkular Alpha13 and up.
    * Set the Hawkular Persona identifier. This is used to impersonate an organization with user credentials.
+   *
+   * @deprecated do not use with Hawkular Alpha13 and up, use {@link #setTenant(String)} instead
    */
+  @Deprecated
   public HawkularServerOptions setPersona(String persona) {
     this.persona = persona;
+    return this;
+  }
+
+  /**
+   * @return the Hawkular tenant
+   */
+  public String getTenant() {
+    return tenant;
+  }
+
+  /**
+   * Set the Hawkular tenant. Defaults to {@code hawkular}.
+   */
+  public HawkularServerOptions setTenant(String tenant) {
+    this.tenant = tenant;
     return this;
   }
 }

--- a/src/main/java/io/vertx/ext/hawkular/impl/Sender.java
+++ b/src/main/java/io/vertx/ext/hawkular/impl/Sender.java
@@ -86,8 +86,8 @@ public class Sender implements Handler<List<DataPoint>> {
         persona = null;
         break;
       case HAWKULAR:
-        tenant = null;
         HawkularServerOptions hawkularServerOptions = options.getHawkularServerOptions();
+        tenant = hawkularServerOptions.getTenant();
         String authString = hawkularServerOptions.getId() + ":" + hawkularServerOptions.getSecret();
         try {
           auth = "Basic " + Base64.getEncoder().encodeToString(authString.getBytes("UTF-8"));
@@ -153,6 +153,8 @@ public class Sender implements Handler<List<DataPoint>> {
         request.putHeader(HttpHeaders.AUTHORIZATION, auth);
         if (persona != null) {
           request.putHeader(HTTP_HEADER_HAWKULAR_PERSONA, persona);
+        } else {
+          request.putHeader(HTTP_HEADER_HAWKULAR_TENANT, tenant);
         }
         break;
       default:

--- a/src/main/java/io/vertx/ext/hawkular/package-info.java
+++ b/src/main/java/io/vertx/ext/hawkular/package-info.java
@@ -88,7 +88,7 @@
  * {@link examples.MetricsExamples#setupTenant()}
  * ----
  *
- * ==== Authentication with a Hawkular server
+ * ==== Tenant selection and authentication with a Hawkular server
  *
  * Requests sent to an Hawkular server must be authenticated:
  *
@@ -96,6 +96,8 @@
  * ----
  * {@link examples.MetricsExamples#setupHawkularAuth()}
  * ----
+ *
+ * The tenant option may be omitted, and will default to `hawkular`.
  *
  * === HTTPS and other HTTP related options
  *


### PR DESCRIPTION
Deprecated persona option. In Sender.java, set tenant header if persona
option is not set.

I did not simply remove the code because there are demo apps which still
need to work with pre Alpha13 versions of Hawkular.
